### PR TITLE
Install under php7

### DIFF
--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -2,7 +2,7 @@
 php.version 5.0;
 
 #PHP extensions
-php.extensions PDO, mbstring, zip, zlib, ftp, json, dom, gd, mysql;
+php.extensions PDO, mbstring, zip, zlib, ftp, json, dom, gd;
 
 #PHP.ini configuration
 ini.safe_mode off;


### PR DESCRIPTION
Oxwall use php pdo, not mysql. This module is not available in php 7 and the installer stucks in requeriments page, but the program is installable once this requeriment is gone.