### PR TITLE
Update install.php

### DIFF
--- a/controllers/install.php
+++ b/controllers/install.php
@@ -70,6 +70,18 @@ class INSTALL_CTRL_Install extends INSTALL_ActionController
 
                         case 'extensions':
                             $requiredExtensions = array_map('trim', explode(',', $value));
+                            
+                           // begin mod
+                           //if php7+ then remove mysql from required extensions                            
+                           $phpVersion = phpversion();                            
+                           if( (int) $phpVersion > 6)
+                           {
+                                 $delvalue = 'mysql';
+                                 $keyvalue = array_search($delvalue, $requiredExtensions);
+                                 unset($requiredExtensions[$keyvalue]); 
+                            }
+                           //end mod                             
+                            
                             $loadedExtensions = get_loaded_extensions();
                             $diff = array_values(array_diff($requiredExtensions, $loadedExtensions));
                             if ( !empty($diff) )


### PR DESCRIPTION
if php is higher than 6 then the install will fail due to mysql deprecation.  So the change checks for php > 6 and if true then it removes the mysql from the extension requirement array. 